### PR TITLE
Enable external plugin dependencies

### DIFF
--- a/src/main/scala/org/jetbrains/sbtidea/tasks/UpdateIdea.scala
+++ b/src/main/scala/org/jetbrains/sbtidea/tasks/UpdateIdea.scala
@@ -15,7 +15,7 @@ object UpdateIdea {
             externalPlugins: Seq[IdeaPlugin],
             streams: TaskStreams): Unit = {
     try {
-      doUpdate(baseDir, IdeaEdition.Community, build, downloadSources = true, Seq.empty, streams)
+      doUpdate(baseDir, IdeaEdition.Community, build, downloadSources = true, externalPlugins, streams)
     } catch {
       case e: sbt.TranslatedException if e.getCause.isInstanceOf[java.io.FileNotFoundException] =>
         val newBuild = build.split('.').init.mkString(".") + "-EAP-CANDIDATE-SNAPSHOT"


### PR DESCRIPTION
With the current version of this project, I couldn't include an external plugin as a dependencies. I don't know if this is a bug or if you intentionally disabled this feature, but the fix in this commit worked for my use case.