### PR TITLE
Use contains on evictedReason instead of get since it can be None sometimes.

### DIFF
--- a/src/main/scala/org/jetbrains/sbtidea/tasks/packaging/TransitiveDeps.scala
+++ b/src/main/scala/org/jetbrains/sbtidea/tasks/packaging/TransitiveDeps.scala
@@ -7,7 +7,7 @@ class TransitiveDeps(report: UpdateReport, configuration: String)(implicit scala
     val evicted:   Seq[ModuleKey]                 = report.configurations
       .find(_.configuration.toString().contains(configuration))
       .map (_.details.flatMap(_.modules)
-          .filter(m => m.evicted && m.evictedReason.get == "latest-revision")
+          .filter(m => m.evicted && m.evictedReason.contains("latest-revision"))
         .map(_.module.key)
       ).getOrElse(Seq.empty)
 


### PR DESCRIPTION
For some reason, evictedReason is None in one of my project. packagePluginZip runs successfully after the change. 

>\> packagePluginZip
...
...
[info] building mappings
[error] java.util.NoSuchElementException: None.get
[error]         at scala.None$.get(Option.scala:349)
[error]         at scala.None$.get(Option.scala:347)
[error]         at org.jetbrains.sbtidea.tasks.packaging.TransitiveDeps.$anonfun$evicted$4(TransitiveDeps.scala:10)
[error]         at org.jetbrains.sbtidea.tasks.packaging.TransitiveDeps.$anonfun$evicted$4$adapted(TransitiveDeps.scala:10)
[error]         at scala.collection.TraversableLike.$anonfun$filterImpl$1(TraversableLike.scala:247)
[error]         at scala.collection.Iterator.foreach(Iterator.scala:937)
[error]         at scala.collection.Iterator.foreach$(Iterator.scala:937)
[error]         at scala.collection.AbstractIterator.foreach(Iterator.scala:1425)
[error]         at scala.collection.IterableLike.foreach(IterableLike.scala:70)
[error]         at scala.collection.IterableLike.foreach$(IterableLike.scala:69)
[error]         at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
[error]         at scala.collection.TraversableLike.filterImpl(TraversableLike.scala:246)
[error]         at scala.collection.TraversableLike.filterImpl$(TraversableLike.scala:244)
[error]         at scala.collection.AbstractTraversable.filterImpl(Traversable.scala:104)
[error]         at scala.collection.TraversableLike.filter(TraversableLike.scala:258)
[error]         at scala.collection.TraversableLike.filter$(TraversableLike.scala:258)
[error]         at scala.collection.AbstractTraversable.filter(Traversable.scala:104)
[error]         at org.jetbrains.sbtidea.tasks.packaging.TransitiveDeps.$anonfun$evicted$2(TransitiveDeps.scala:10)
[error]         at scala.Option.map(Option.scala:146)
[error]         at org.jetbrains.sbtidea.tasks.packaging.TransitiveDeps.<init>(TransitiveDeps.scala:11)
[error]         at org.jetbrains.sbtidea.tasks.packaging.StructureBuilder.buildStructure$1(StructureBuilder.scala:68)
[error]         at org.jetbrains.sbtidea.tasks.packaging.StructureBuilder.$anonfun$artifactMappings$34(StructureBuilder.scala:129)
[error]         at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:233)
[error]         at scala.collection.immutable.List.foreach(List.scala:388)
[error]         at scala.collection.TraversableLike.map(TraversableLike.scala:233)
[error]         at scala.collection.TraversableLike.map$(TraversableLike.scala:226)
[error]         at scala.collection.immutable.List.map(List.scala:294)
[error]         at org.jetbrains.sbtidea.tasks.packaging.StructureBuilder.artifactMappings(StructureBuilder.scala:129)
[error]         at org.jetbrains.sbtidea.Keys$.$anonfun$projectSettings$24(Keys.scala:302)
[error]         at sbt.std.Transform$$anon$3.$anonfun$apply$2(System.scala:46)
[error]         at sbt.std.Transform$$anon$4.work(System.scala:67)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error]         at sbt.Execute.work(Execute.scala:278)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[error]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[error]         at java.lang.Thread.run(Thread.java:745)
[error] (packageMappings) java.util.NoSuchElementException: None.get