### PR TITLE
Fix shadowing issues

### DIFF
--- a/src/main/scala/org/jetbrains/sbtidea/tasks/packaging/artifact/ClassShader.scala
+++ b/src/main/scala/org/jetbrains/sbtidea/tasks/packaging/artifact/ClassShader.scala
@@ -9,7 +9,7 @@ import sbt.Keys.TaskStreams
 
 class ClassShader(patterns: Seq[ShadePattern])(implicit val streams: TaskStreams) {
 
-  private val processor = new JJProcessor(patterns.map {
+  private val processor = new NiceJJProcessor(patterns.map {
     case ShadePattern(pat, res) =>
       val jRule = new Rule()
       jRule.setPattern(pat)

--- a/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
+++ b/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
@@ -2,4 +2,4 @@ package org.pantsbuild.jarjar
 
 import scala.collection.JavaConverters.seqAsJavaListConverter
 
-class JJProcessor(rules: Seq[PatternElement]) extends MainProcessor(rules.asJava, false, false)
+class NiceJJProcessor(rules: Seq[PatternElement]) extends MainProcessor(rules.asJava, false, false)


### PR DESCRIPTION
If build definition contaians sbt assemble (or other plugin depending on pats/jarjar) packagePluginZip sometimes (depdends on file sytem or something) fails with:

```
[info] Done compiling.
[error] java.lang.NoSuchMethodError: org.pantsbuild.jarjar.JJProcessor.<init>(Lscala/collection/Seq;)V
[error] 	at FixJarJar$.doFix(BrokenJarJar.scala:10)
[error] 	at $56b8d6d3da71dd14cbdc$.$sbtdef(/home/krzysiek/workspace/contextbuddy/build.sbt:78)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

This PR fixes the problem.