### PR TITLE
Always download Idea Community sources

### DIFF
--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/JBIdeaRepoArtifactResolver.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/JBIdeaRepoArtifactResolver.scala
@@ -2,6 +2,7 @@ package org.jetbrains.sbtidea.download
 
 import java.io.{FileNotFoundException, InputStream}
 
+import org.jetbrains.sbtidea.Keys
 import org.jetbrains.sbtidea.download.api.IdeaResolver
 import sbt.{URL, url}
 
@@ -9,15 +10,16 @@ trait JBIdeaRepoArtifactResolver extends IdeaResolver {
 
   override def resolveUrlForIdeaBuild(idea: BuildInfo): Seq[ArtifactPart] = {
     val (build, edition)  = (idea.buildNumber, idea.edition.name)
-    val ideaUrl           = getUrl(idea) { build => s"$edition-$build.zip" }
-    val srcJarUrl         = getUrl(idea) { build => s"$edition-$build-sources.jar" }
+    val ideaUrl           = getUrl(idea, ".zip")
+    // sources are available only for Community Edition
+    val srcJarUrl         = getUrl(idea.copy(edition = Keys.IdeaEdition.Community), "-sources.jar")
 
     ArtifactPart(ideaUrl, ArtifactKind.IDEA_DIST, s"$edition-$build.zip") ::
       ArtifactPart(srcJarUrl, ArtifactKind.IDEA_SRC, s"$edition-$build-sources.jar", optional = true) :: Nil
   }
 
   //noinspection NoTailRecursionAnnotation
-  protected def getUrl(idea: BuildInfo, trySnapshot: Boolean = false)(artName: String => String): URL = {
+  protected def getUrl(idea: BuildInfo, artifactSuffix: String, trySnapshot: Boolean = false): URL = {
     val (repo, suffix)  =
       if      (trySnapshot)                           "snapshots" -> "-EAP-SNAPSHOT"
       else if (idea.buildNumber.contains("SNAPSHOT")) "snapshots" -> ""
@@ -26,13 +28,13 @@ trait JBIdeaRepoArtifactResolver extends IdeaResolver {
     val build           = idea.buildNumber + suffix
     var stream: Option[InputStream] = None
     try {
-      val result  = url(s"$baseUrl/${idea.edition.name}/$build/${artName(build)}")
+      val result  = url(s"$baseUrl/${idea.edition.name}/$build/${idea.edition.name}-$build$artifactSuffix")
       stream      = Some(result.openStream())
       result
     } catch {
       case _: FileNotFoundException if !trySnapshot && !idea.buildNumber.endsWith("SNAPSHOT") =>
         println(s"Can't find $idea in releases, trying snapshots")
-        getUrl(idea, trySnapshot = true)(artName)
+        getUrl(idea, artifactSuffix, trySnapshot = true)
     } finally {
       stream.foreach(_.close())
     }


### PR DESCRIPTION
Hi. I discovered an issue when Ultimate Edition is used. When idea edition is Ultimate Edition, the plugin tries to download Ultimate Edition sources which are obviously not available and sdk update fails. I think this is normal that Ultimate Eidition sources are not available and Community Edition sources should be downloaded instead. This PR does exactly what I described.

Regards.