### PR TITLE
Allow non-digit characters in version ID of intellijExternalPlugins

### DIFF
--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Defns.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Defns.scala
@@ -14,7 +14,7 @@ trait Defns { this: Keys.type =>
      { override def toString: String = id }
 
     val URL_PATTERN: Pattern = Pattern.compile("^(?:(\\w+):)??(https?://.+)$")
-    val ID_PATTERN:  Pattern = Pattern.compile("^([\\w.]+):?([\\d.]+)?:?([\\w]+)?$")
+    val ID_PATTERN:  Pattern = Pattern.compile("^([\\w.]+):?([\\w.]+)?:?([\\w]+)?$")
 
     def isExternalPluginStr(str: String): Boolean =
       str.contains(":") || ID_PATTERN.matcher(str).matches() || URL_PATTERN.matcher(str).matches()


### PR DESCRIPTION
Some plugins have versioning patterns allowing non-digit characters. 
Currently, the `intellijExternalPlugins` allows only digits and dots.

Example plugin that use non-digit characters:

Grazie plugin - for dev/alpha channels - https://plugins.jetbrains.com/plugin/12175-grazie/versions
Pants plugin - for Bleedingedge channel - https://plugins.jetbrains.com/plugin/7412-pants-support/versions