### PR TITLE
Allow passing an explicit URL to plugin dependencies

### DIFF
--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/IntellijPlugin.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/IntellijPlugin.scala
@@ -10,12 +10,13 @@ sealed trait IntellijPlugin {
 object IntellijPlugin {
   final case class Url(url: URL) extends IntellijPlugin
     { override def toString: String = url.toString }
-  final case class Id(id: String, version: Option[String], channel: Option[String]) extends IntellijPlugin
+  final case class Id(id: String, version: Option[String], channel: Option[String])(val url: Option[URL] = None) extends IntellijPlugin
    { override def toString: String = id }
   final case class BundledFolder(name: String) extends IntellijPlugin
 
   val URL_PATTERN: Pattern = Pattern.compile("^(?:(\\w+):)??(https?://.+)$")
   val ID_PATTERN:  Pattern = Pattern.compile("^([^:]+):?([\\w.]+)?:?([\\w]+)?$")
+  val ID_WITH_URL: Pattern = Pattern.compile("^([^:]+):?([\\w.-]+)?:?(https?://.+)?$")
 
   case class Settings(transitive: Boolean = true, optionalDeps: Boolean = true, excludedIds: Set[String] = Set.empty)
   val defaultSettings: Settings = Settings()

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Utils.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Utils.scala
@@ -8,11 +8,17 @@ trait Utils {
     def toPlugin: IntellijPlugin = {
       val idMatcher  = ID_PATTERN.matcher(str)
       val urlMatcher = URL_PATTERN.matcher(str)
+      val idWithUrlMatcher = ID_WITH_URL.matcher(str)
       if (idMatcher.find()) {
         val id = idMatcher.group(1)
         val version = Option(idMatcher.group(2))
         val channel = Option(idMatcher.group(3))
-        IntellijPlugin.Id(id, version, channel)
+        IntellijPlugin.Id(id, version, channel)()
+      } else if (idWithUrlMatcher.matches()) {
+        val id = idWithUrlMatcher.group(1)
+        val version = Option(idWithUrlMatcher.group(2))
+        val url = Option(idWithUrlMatcher.group(3)).map(new URL(_))
+        IntellijPlugin.Id(id, version, None)(url)
       } else if (urlMatcher.find()) {
         val name = Option(urlMatcher.group(1)).getOrElse("")
         val url  = urlMatcher.group(2)

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/plugin/PluginRepoUtils.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/plugin/PluginRepoUtils.scala
@@ -22,17 +22,18 @@ class PluginRepoUtils(implicit ctx: InstallContext) extends PluginRepoApi {
   }
 
   def getPluginDownloadURL(idea: BuildInfo, pluginInfo: IntellijPlugin.Id): URL = {
-    val urlStr = pluginInfo match {
+    pluginInfo match {
       case IntellijPlugin.Id(id, Some(version), Some(channel)) =>
-        s"$baseUrl/plugin/download?pluginId=$id&version=$version&channel=$channel"
+        assert(pluginInfo.url.isEmpty, "Can't specify both channel and download URL.")
+        new URL(s"$baseUrl/plugin/download?pluginId=$id&version=$version&channel=$channel")
       case IntellijPlugin.Id(id, Some(version), None) =>
-        s"$baseUrl/plugin/download?pluginId=$id&version=$version"
+        pluginInfo.url.getOrElse(new URL(s"$baseUrl/plugin/download?pluginId=$id&version=$version"))
       case IntellijPlugin.Id(id, None, Some(channel)) =>
-        s"$baseUrl/pluginManager?action=download&id=$id&channel=$channel&build=${idea.edition.edition}-${idea.getActualIdeaBuild(ctx.baseDirectory)}"
+        assert(pluginInfo.url.isEmpty, "Can't specify both channel and download URL.")
+        new URL(s"$baseUrl/pluginManager?action=download&id=$id&channel=$channel&build=${idea.edition.edition}-${idea.getActualIdeaBuild(ctx.baseDirectory)}")
       case IntellijPlugin.Id(id, None, None) =>
-        s"$baseUrl/pluginManager?action=download&id=$id&build=${idea.edition.edition}-${idea.getActualIdeaBuild(ctx.baseDirectory)}"
+        pluginInfo.url.getOrElse(new URL(s"$baseUrl/pluginManager?action=download&id=$id&build=${idea.edition.edition}-${idea.getActualIdeaBuild(ctx.baseDirectory)}"))
     }
-    new URL(urlStr)
   }
 
   def getLatestPluginVersion(idea: BuildInfo, pluginId: String, channel: Option[String]): Either[Throwable, String] =

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/plugin/PluginResolver.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/plugin/PluginResolver.scala
@@ -53,7 +53,7 @@ class PluginResolver(private val processedPlugins: Set[IntellijPlugin] = Set.emp
         sbt.IO.unzip(downloadedFile.toFile, extractDir.toFile)
         assert(Files.list(extractDir).count() == 1, s"Expected only single plugin folder in extracted archive, got: ${extractDir.toFile.list().mkString}")
         val tmpPluginDir = Files.list(extractDir).findFirst().get()
-        LocalPluginRegistry.extractInstalledPluginDescriptor(tmpPluginDir).map(PluginDescriptor.load)
+        LocalPluginRegistry.extractInstalledPluginDescriptor(tmpPluginDir).right.map(PluginDescriptor.load)
       } else repo.getRemotePluginXmlDescriptor(plugin.buildInfo, key.id, key.channel)
 
     descriptor match {

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/plugin/PluginResolver.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/download/plugin/PluginResolver.scala
@@ -1,7 +1,10 @@
 package org.jetbrains.sbtidea.download.plugin
 import org.jetbrains.sbtidea.Keys.String2Plugin
 import org.jetbrains.sbtidea._
+import org.jetbrains.sbtidea.download.FileDownloader
 import org.jetbrains.sbtidea.download.api._
+
+import java.nio.file.Files
 
 
 class PluginResolver(private val processedPlugins: Set[IntellijPlugin] = Set.empty, private val resolveSettings: IntellijPlugin.Settings)
@@ -44,8 +47,14 @@ class PluginResolver(private val processedPlugins: Set[IntellijPlugin] = Set.emp
     val descriptor =
       if (alreadyInstalled)
         localRegistry.getPluginDescriptor(key)
-      else
-        repo.getRemotePluginXmlDescriptor(plugin.buildInfo, key.id, key.channel)
+      else if (key.url.isDefined) {
+        val downloadedFile = FileDownloader(ctx.downloadDirectory).download(key.url.get)
+        val extractDir = Files.createTempDirectory(ctx.downloadDirectory, s"tmp-resolve-downloads")
+        sbt.IO.unzip(downloadedFile.toFile, extractDir.toFile)
+        assert(Files.list(extractDir).count() == 1, s"Expected only single plugin folder in extracted archive, got: ${extractDir.toFile.list().mkString}")
+        val tmpPluginDir = Files.list(extractDir).findFirst().get()
+        LocalPluginRegistry.extractInstalledPluginDescriptor(tmpPluginDir).map(PluginDescriptor.load)
+      } else repo.getRemotePluginXmlDescriptor(plugin.buildInfo, key.id, key.channel)
 
     descriptor match {
       case Right(descriptor) =>
@@ -53,8 +62,10 @@ class PluginResolver(private val processedPlugins: Set[IntellijPlugin] = Set.emp
         val thisPluginArtifact =
           if (alreadyInstalled)
             LocalPlugin(plugin, descriptor, localRegistry.getInstalledPluginRoot(key))
-          else
-            RemotePluginArtifact(plugin, repo.getPluginDownloadURL(plugin.buildInfo, key))
+          else {
+            val url = key.url.getOrElse(repo.getPluginDownloadURL(plugin.buildInfo, key))
+            RemotePluginArtifact(plugin, url)
+          }
 
         val resolvedDeps =
           if (resolveSettings.transitive)
@@ -89,5 +100,4 @@ class PluginResolver(private val processedPlugins: Set[IntellijPlugin] = Set.emp
       Seq.empty
     }
   }
-
 }

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/IntellijPluginInstallerTest.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/IntellijPluginInstallerTest.scala
@@ -57,7 +57,7 @@ final class IntellijPluginInstallerTest extends IntellijPluginInstallerTestBase 
     val pluginMetadata = PluginDescriptor("org.intellij.scala", "JetBrains", "Scala", "2019.2.1", "211.0", "211.*")
     val mockPluginDist = createPluginJarMock(pluginMetadata)
     val installer = createInstaller
-    val pluginId = pluginMetadata.toPluginId.copy(version = None)
+    val pluginId = pluginMetadata.toPluginId.copy(version = None)(None)
     installer.installIdeaPlugin(pluginId, mockPluginDist)
 
     val messages = captureLog(installer.isInstalled(pluginId) shouldBe false)

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/IntellijPluginParserTest.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/IntellijPluginParserTest.scala
@@ -4,6 +4,7 @@ import org.jetbrains.sbtidea.IntellijPlugin._
 import org.jetbrains.sbtidea.Keys.String2Plugin
 import org.scalatest.{FunSuite, Matchers}
 
+import java.net.URL
 import scala.language.postfixOps
 
 final class IntellijPluginParserTest extends FunSuite with Matchers {
@@ -17,7 +18,17 @@ final class IntellijPluginParserTest extends FunSuite with Matchers {
   test("plugin url should parse as Url") {
     "https://foo.bar/a.zip".toPlugin shouldBe an [Url]
     "http://foo.bar/a.zip".toPlugin shouldBe an [Url]
-    "plugin:http://foo.bar/a.zip".toPlugin shouldBe an [Url]
+  }
+
+  test("plugin with url should parse as Id with optional URL set") {
+    val p = "org.example.plugin:http://foo.bar/a.zip".toPlugin
+    p shouldBe an [Id]
+    p.asInstanceOf[Id].url shouldEqual Some(new URL("http://foo.bar/a.zip"))
+
+    val p1 = "org.example.plugin:1.0-api-212:https://foo.bar/a.zip".toPlugin
+    p1 shouldBe an [Id]
+    p1.asInstanceOf[Id].url shouldEqual Some(new URL("https://foo.bar/a.zip"))
+    p1.asInstanceOf[Id].version shouldEqual Some("1.0-api-212")
   }
 
   test("id should parse with with mixed segments") {

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/IntellijPluginResolverTestBase.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/IntellijPluginResolverTestBase.scala
@@ -26,7 +26,7 @@ abstract class IntellijPluginResolverTestBase extends IntellijPluginInstallerTes
     Seq(pluginA, pluginB, pluginC, pluginD, pluginE).map(p => p.id -> p).toMap
 
   protected implicit def descriptor2Plugin(descriptor: PluginDescriptor): PluginDependency =
-      PluginDependency(IntellijPlugin.Id(descriptor.id, None, None),
+      PluginDependency(IntellijPlugin.Id(descriptor.id, None, None)(),
         IDEA_BUILDINFO,
         descriptor.dependsOn.map(p => plugin2PluginDep(p.id.toPlugin)))
 

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/PluginMock.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/download/plugin/PluginMock.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 trait PluginMock extends TmpDirUtils {
 
   implicit class PluginMetaDataExt(metadata: PluginDescriptor) {
-    def toPluginId: IntellijPlugin.Id = IntellijPlugin.Id(metadata.id, Some(metadata.version), None)
+    def toPluginId: IntellijPlugin.Id = IntellijPlugin.Id(metadata.id, Some(metadata.version), None)()
   }
 
   protected def createPluginJarMock(metaData: PluginDescriptor): Path = {


### PR DESCRIPTION
In order to add a dependency to a private repository, we must allow passing a direct download URL. If specified, the URL takes precedence on the logic to build a download URL based on the JetBrains plugin repo API.

This implements plugin dependencies of the form:

```
com.databricks.plugin:1.0:https://path/to/plugin.zip
```

Fixes #114