### PR TITLE
Exclude `com.intellij.openapi.vfs.impl.FilePartNodeRoot#trieDescend` from compilation

### DIFF
--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/runIdea/IntellijVMOptions.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/runIdea/IntellijVMOptions.scala
@@ -125,6 +125,8 @@ object IntellijVMOptions {
       |-Djdk.module.illegalAccess.silent=true
       |-XX:+IgnoreUnrecognizedVMOptions
       |
+      |-XX:CompileCommand=exclude,com/intellij/openapi/vfs/impl/FilePartNodeRoot,trieDescend
+      |
       |--add-opens=java.base/java.io=ALL-UNNAMED
       |--add-opens=java.base/java.lang=ALL-UNNAMED
       |--add-opens=java.base/java.lang.reflect=ALL-UNNAMED


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/JBR-4509

Internally confirmed that the issue also applies to non-JBR runtimes: https://jetbrains.slack.com/archives/C0DL2QKBP/p1693406522086339