### PR TITLE
Fix race in packageArtifact for doPatchPluginXml

### DIFF
--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Init.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Init.scala
@@ -127,13 +127,11 @@ trait Init { this: Keys.type =>
         filterScalaLibraryCp(previousValue)
     },
     packageArtifact := {
-      doPatchPluginXml.value
-      packageArtifact.value
-    },
+      packageArtifact dependsOn Def.sequential(packageMappings, doPatchPluginXml)
+    }.value,
     packageArtifactDynamic := {
-      doPatchPluginXml.value
-      packageArtifactDynamic.value
-    },
+      packageArtifactDynamic dependsOn Def.sequential(packageMappings, doPatchPluginXml)
+    }.value,
     packageArtifactZip := Def.sequential(
       buildIntellijOptionsIndex.toTask,
       doPackageArtifactZip.toTask,

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Init.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Init.scala
@@ -127,9 +127,11 @@ trait Init { this: Keys.type =>
         filterScalaLibraryCp(previousValue)
     },
     packageArtifact := {
+      // packageMappings must complete before patching
       packageArtifact dependsOn Def.sequential(packageMappings, doPatchPluginXml)
     }.value,
     packageArtifactDynamic := {
+      // packageMappings must complete before patching
       packageArtifactDynamic dependsOn Def.sequential(packageMappings, doPatchPluginXml)
     }.value,
     packageArtifactZip := Def.sequential(


### PR DESCRIPTION
When running `packageArtifact`, `doPatchPluginXml` fails to patch the xml because it races w/ `packageMappings`