### PR TITLE
Allow PluginXmlPatcher to patch multi-line tags

### DIFF
--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/xml/PluginXmlPatcher.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/xml/PluginXmlPatcher.scala
@@ -48,12 +48,18 @@ class PluginXmlPatcher(input: Path, createCopy: Boolean = false) {
     content
   }
 
-  private def tag(str: String, name: String, value: String): String =
-    if (str.matches(s"(?s)^.*<$name>.+</$name>.*$$"))
-    str.replaceAll(s"<$name>.+</$name>", s"<$name>$value</$name>")
-  else {
-    log.warn(s"$input doesn't have $name tag defined, not patching")
-    str
+  private def tag(str: String, name: String, value: String): String = {
+    val tagPattern = s"(?s)<$name>.*?</$name>".r
+    val matchCount: Int = tagPattern.findAllIn(str).length
+    if (matchCount > 0) {
+      if (matchCount > 1) {
+        log.warn(s"$input have multiple $name tag defined, only patching the first one")
+      }
+      tagPattern.replaceFirstIn(str, s"<$name>$value</$name>")
+    }
+    else {
+      log.warn(s"$input doesn't have $name tag defined, not patching")
+      str
+    }
   }
-
 }

--- a/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-duplicatedtags-golden.xml
+++ b/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-duplicatedtags-golden.xml
@@ -3,15 +3,9 @@
     <!--    <description>This is
     comment 2</description>   -->
 <!--<description>This is comment 3</description>12345-->
-    <description>Integrates Volume Snapshot Service W10
-    This is a very
-    long description.
-    It has multiple lines.
-    </description>
+    <description>DESCRIPTION
+LINE2</description>
 <!--    <description>This is comment 4</description>-->
-    <description>Integrates Volume Snapshot Service W10
-        This is a very
-        long description.
-        It has multiple lines.
-    </description>
+    <description>DESCRIPTION
+LINE2</description>
 </idea-plugin>

--- a/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-duplicatedtags.xml
+++ b/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-duplicatedtags.xml
@@ -1,0 +1,8 @@
+<idea-plugin url="https://www.jetbrains.com/idea">
+    <description>Integrates Volume Snapshot Service W10
+    This is a very
+    long description.
+    It have multiple lines.
+    </description>
+<!--    <description>This is comment</description>-->
+</idea-plugin>

--- a/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-multilinetag-golden.xml
+++ b/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-multilinetag-golden.xml
@@ -1,0 +1,4 @@
+<idea-plugin url="https://www.jetbrains.com/idea">
+    <description>DESCRIPTION
+LINE2</description>
+</idea-plugin>

--- a/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-multilinetag.xml
+++ b/ideaSupport/src/test/resources/org/jetbrains/sbtidea/xml/plugin-multilinetag.xml
@@ -1,0 +1,7 @@
+<idea-plugin url="https://www.jetbrains.com/idea">
+    <description>Integrates Volume Snapshot Service W10
+    This is a very
+    long description.
+    It have multiple lines.
+    </description>
+</idea-plugin>

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/xml/PluginXmlPatchingTest.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/xml/PluginXmlPatchingTest.scala
@@ -9,7 +9,7 @@ import java.nio.file.{Files, StandardCopyOption}
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 import scala.util.Using
 
-private class PluginXmlPatchingTest extends AnyFunSuite with Matchers with IdeaMock {
+class PluginXmlPatchingTest extends AnyFunSuite with Matchers with IdeaMock {
 
   private def getPluginXml(pluginXmlName: String = "plugin.xml") = {
     val tmpFile = createTempFile("", "plugin.xml")

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/xml/PluginXmlPatchingTest.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/xml/PluginXmlPatchingTest.scala
@@ -107,13 +107,13 @@ class PluginXmlPatchingTest extends AnyFunSuite with Matchers with IdeaMock {
     }
     val patcher = new PluginXmlPatcher(pluginXml)
     val result = patcher.patch(options)
-    val newContent = Files.readAllLines(result).asScala
+    val newContent = Files.readAllLines(result).asScala.mkString("\n")
 
-    val newContentPattern = s"(?s).*<description>${options.pluginDescription}</description>.*$$".r
-    newContent.mkString("\n") should fullyMatch regex newContentPattern
+    val golden = Files.readAllLines(getPluginXml("plugin-multilinetag-golden.xml")).asScala.mkString("\n")
+    newContent shouldBe golden
   }
 
-  test("duplicate tags are only patched the first one") {
+  test("duplicate tags are only patched the uncommented first one") {
     val pluginXml = getPluginXml("plugin-duplicatedtags.xml")
 
     val options = pluginXmlOptions { xml =>
@@ -121,11 +121,9 @@ class PluginXmlPatchingTest extends AnyFunSuite with Matchers with IdeaMock {
     }
     val patcher = new PluginXmlPatcher(pluginXml)
     val result = patcher.patch(options)
-    val newContent = Files.readAllLines(result).asScala
+    val newContent = Files.readAllLines(result).asScala.mkString("\n")
 
-    val pattern1 = s"(?s)<description>.*?</description>".r
-    pattern1.findAllMatchIn(newContent.mkString("\n")).size shouldBe 2
-    val pattern2 = s"(?s).*<description>${options.pluginDescription}</description>.*<description>.*</description>.*$$".r
-    newContent.mkString("\n") should fullyMatch regex pattern2
+    val golden = Files.readAllLines(getPluginXml("plugin-duplicatedtags-golden.xml")).asScala.mkString("\n")
+    newContent shouldBe golden
   }
 }


### PR DESCRIPTION
If my plugin.xml have a multi-line tag (i.e., includes '\n') like this:
```xml
<idea-plugin>
    ...
    <description>
        determined by build.sbt
        some else
    </description>
    ...
```
the current PluginXmlPatcher cannot patch it correctly. 
The current code is:
```scala
    if (str.matches(s"(?s)^.*<$name>.+</$name>.*$$"))
        str.replaceAll(s"<$name>.+</$name>", s"<$name>$value</$name>")
    else {
       log.warn(s"$input doesn't have $name tag defined, not patching")
       ...
```
Detailed reason analysis:

The regex in the if-condition with "(?s)" enables DOTALL mode, so it can match the string with '\n'. And, the regex in the `replace` statement does not have a "(?s)", so it cannot match multiline tags, and nothing will be replaced.


