### PR TITLE
Add hidden sbt key for extra JUnit template library dependencies #SCL-25373

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -11,13 +11,13 @@ jobs:
     name: sbt-idea-plugin plugin Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - uses: coursier/cache-action@v6
+      - uses: coursier/cache-action@v8
       - name: Compile & Test
         run: sbt test

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Init.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Init.scala
@@ -124,6 +124,11 @@ trait Init { this: Keys.type =>
 
     intellijPlugins := Seq.empty,
     intellijExtraRuntimePluginsInTests := Seq.empty,
+    intellijExtraJUnitTemplateLibraryDependencies := Seq.empty,
+
+    ivyConfigurations += intellijJUnitTemplateConfig,
+    libraryDependencies ++= intellijExtraJUnitTemplateLibraryDependencies.value
+      .map(_ % intellijJUnitTemplateConfig),
 
     intellijMainJarsClasspath := AttributedClasspathTasks.main.value,
     intellijTestJarsClasspath := AttributedClasspathTasks.test.value,

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Keys.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/Keys.scala
@@ -27,6 +27,14 @@ object Keys extends Defns with Init with Utils with Quirks {
   lazy val intellijExtraRuntimePluginsInTests = settingKey[Seq[IntellijPlugin]](
     "List of IntelliJ platform plugins to include in tests at runtime")
 
+  lazy val intellijExtraJUnitTemplateLibraryDependencies = settingKey[Seq[ModuleID]](
+    "Extra library dependencies provided only on the JUnit test Run Configuration template classpath " +
+      "(generated during IDEA project import). These do not affect the sbt Test classpath."
+  ).withRank(sbt.KeyRanks.Invisible)
+
+  private[sbtidea] lazy val intellijJUnitTemplateConfig: Configuration =
+    Configuration.of("IntellijJUnitTemplate", "intellij-junit-template").hide
+
   @Deprecated(forRemoval = true)
   @deprecated("The setting is ignored and will be removed in future versions. The sources are always downloaded")
   lazy val intellijDownloadSources = settingKey[Boolean](

--- a/ideaSupport/src/main/scala/org/jetbrains/sbtidea/tasks/classpath/TestClasspathTasks.scala
+++ b/ideaSupport/src/main/scala/org/jetbrains/sbtidea/tasks/classpath/TestClasspathTasks.scala
@@ -1,9 +1,10 @@
 package org.jetbrains.sbtidea.tasks.classpath
 
+import org.jetbrains.sbtidea.Keys.intellijJUnitTemplateConfig
 import org.jetbrains.sbtidea.packaging.PackagingKeys.packageOutputDir
 import sbt.*
 import sbt.Def.Classpath
-import sbt.Keys.{exportedProductsNoTracking, externalDependencyClasspath}
+import sbt.Keys.{classpathTypes, exportedProductsNoTracking, externalDependencyClasspath, update}
 
 import scala.collection.mutable
 
@@ -36,7 +37,14 @@ object TestClasspathTasks {
     val outputDir = packageOutputDir.value
     val pluginPlaceholderPatterns = PluginClasspathUtils.pluginClasspathPattern(outputDir)
     val commonClasspath = commonTestClasspath.value
-    pluginPlaceholderPatterns ++ commonClasspath.map(_.data.getAbsolutePath)
+    val extraTemplateJars = Classpaths.managedJars(
+      intellijJUnitTemplateConfig,
+      classpathTypes.value,
+      update.value
+    )
+    pluginPlaceholderPatterns ++
+      commonClasspath.map(_.data.getAbsolutePath) ++
+      extraTemplateJars.map(_.data.getAbsolutePath)
   }
 
   /**

--- a/ideaSupport/src/test/scala/org/jetbrains/sbtidea/integrationTests/SbtIdeaPluginIntegrationTest.scala
+++ b/ideaSupport/src/test/scala/org/jetbrains/sbtidea/integrationTests/SbtIdeaPluginIntegrationTest.scala
@@ -1,6 +1,7 @@
 package org.jetbrains.sbtidea.integrationTests
 
 import org.jetbrains.sbtidea.download.api.IdeInstallationContext
+import org.jetbrains.sbtidea.testUtils.SbtProjectFilesUtils
 import org.jetbrains.sbtidea.testUtils.SbtProjectFilesUtils.runSbtProcess
 import org.jetbrains.sbtidea.testUtils.IoUtils
 import org.scalatest.matchers.should.Matchers
@@ -121,6 +122,47 @@ class SbtIdeaPluginIntegrationTest
     assertFileExists(junitTemplateFile)
     val junitTemplateText = IoUtils.readLines(junitTemplateFile).mkString(System.lineSeparator())
     junitTemplateText should include("junit_template_argfile.txt")
+  }
+
+  test("intellijExtraJUnitTemplateLibraryDependencies appears only on the JUnit template classpath") {
+    val projectDir = testProjectsDir / "simple-with-plugin"
+
+    // Inject SDK paths/settings into the fixture; this rewrites extra.sbt from a clean state
+    // (runUpdateIntellijCommand calls cleanUntrackedVcsFiles -> git clean -fdx first).
+    runUpdateIntellijCommand(projectDir)
+
+    // Configure one extra dep that should appear ONLY on the generated JUnit template classpath.
+    appendExtraJUnitTemplateLibDepToExtraSbt(projectDir)
+
+    // 1) Generate the JUnit template — the jar must end up in the argfile.
+    runSbtProcess(Seq("createIDEARunConfiguration"), projectDir)
+
+    val argFile = projectDir / ".idea" / "runConfigurations" / "junit_template_argfile.txt"
+    assertFileExists(argFile)
+    val argFileText = IoUtils.readLines(argFile).mkString(System.lineSeparator())
+    argFileText should include("commons-io-2.16.1.jar")
+
+    // 2) The same jar must NOT appear on the sbt Test / fullClasspath.
+    val result = runSbtProcess(
+      Seq("show Test/fullClasspath"),
+      projectDir,
+      ioMode = SbtProjectFilesUtils.IoMode.PrintAndCollectOutput,
+    )
+    val fullClasspathOutput = result.outputLines.getOrElse(Seq.empty).mkString("\n")
+    fullClasspathOutput should not include "commons-io-2.16.1.jar"
+  }
+
+  private def appendExtraJUnitTemplateLibDepToExtraSbt(projectDir: File): Unit = {
+    val extraSbt = projectDir / "extra.sbt"
+    assertFileExists(extraSbt)
+    val current = IoUtils.readLines(extraSbt).mkString(System.lineSeparator())
+    //language=SBT
+    val additional =
+      """
+        |
+        |intellijExtraJUnitTemplateLibraryDependencies += "commons-io" % "commons-io" % "2.16.1"
+        |""".stripMargin
+    IoUtils.writeStringToFile(extraSbt, current + additional)
   }
 
   private def dumpFileStructure(directory: File): String = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.5
+sbt.version=1.12.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
-addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.4")


### PR DESCRIPTION
## Summary

  Introduces a new hidden setting key, `intellijExtraJUnitTemplateLibraryDependencies: SettingKey[Seq[ModuleID]]`, that lets a consuming build add library dependencies that should appear **only** on the JUnit
   Run Configuration template classpath generated during IDEA project import — not on the sbt `Test / fullClasspath`.

  Motivation: when tests are launched from the IDE, some libraries are needed at runtime that are otherwise satisfied differently during in-sbt test runs (e.g. provided by the IntelliJ instance or by an
  upstream module). Until now there was no way to express "extra JAR for the IDE-launched test JVM only" without polluting `Test / fullClasspath`.

  ## Implementation

  - New `settingKey[Seq[ModuleID]]` `intellijExtraJUnitTemplateLibraryDependencies` (`Keys.scala`), hidden via `KeyRanks.Invisible` — settable from `build.sbt` but not surfaced in tab-completion / `tasks`
  listings.
  - New `private[sbtidea]` Ivy `Configuration` `intellijJUnitTemplateConfig` (hidden, no parents). The key's modules are routed into this configuration via `libraryDependencies ++= … .map(_ %
  intellijJUnitTemplateConfig)` in `Init.scala`, so they participate in normal `update` resolution but do not leak into `Compile`/`Test`.
  - `TestClasspathTasks.fullTestClasspathForJUnitTemplate` now appends `Classpaths.managedJars(intellijJUnitTemplateConfig, classpathTypes.value, update.value)` to the template classpath.
  `fullTestClasspathForSbt` is intentionally untouched.

  ## Test plan

  - [x] New integration test `intellijExtraJUnitTemplateLibraryDependencies appears only on the JUnit template classpath` in `SbtIdeaPluginIntegrationTest.scala`. It:
    1. configures `intellijExtraJUnitTemplateLibraryDependencies += "commons-io" % "commons-io" % "2.16.1"` against the `simple-with-plugin` fixture,
    2. runs `createIDEARunConfiguration` and asserts `commons-io-2.16.1.jar` is present in the generated `.idea/runConfigurations/junit_template_argfile.txt`,
    3. runs `show Test/fullClasspath` and asserts the same jar is **absent** from the captured stdout.
  - [x] Manually verified via `publishLocal` against the Scala Plugin repo.