### PR TITLE
Fix core/doc Scaladoc failure from a broken ProjectRef doc-link (#146)

### DIFF
--- a/core/src/main/scala/org/jetbrains/sbtidea/structure/sbtImpl/SbtProjectStructureExtractorBase.scala
+++ b/core/src/main/scala/org/jetbrains/sbtidea/structure/sbtImpl/SbtProjectStructureExtractorBase.scala
@@ -17,7 +17,7 @@ trait SbtProjectStructureExtractorBase extends ProjectStructureExtractor {
   val projectsData: Seq[ProjectDataType]
 
   /**
-   * Maps each [[ProjectRef]] of the current build to its extracted project data.
+   * Maps each `ProjectRef` of the current build to its extracted project data.
    *
    * Only projects that belong to this build (i.e. present in `projectsData`) are included.
    * Projects pulled in via `dependsOn(RootProject(...))` live in their own builds and don't


### PR DESCRIPTION
  Follow-up to #147 (which fixed #146). After the merge, `master` CI went red — this PR greens it.

  ### What's broken

  `core / Compile / doc` fails:

  ```
  SbtProjectStructureExtractorBase.scala:19:3: Could not find any member to link for "ProjectRef".
  one error found
  (core / Compile / doc) Scaladoc generation failed
  ```

  A review-fix doc comment on `projectMap` referenced `sbt.ProjectRef` via a `[[ProjectRef]]` doc-link. `ProjectRef` is an external library type with no Scaladoc
  `apiMapping` on the doc classpath, so the link can't be resolved, and the build fails `doc` on broken links.

  ### Why CI shows it as test failures too

  It's a single root cause. The integration-test setup runs `compile ; publishLocal ; show core / version`; `publishLocal` invokes `doc`, so the child sbt process
  exits 1 and every `publishCurrentSbtIdeaPluginToLocalRepoAndGetVersions`-based test fails (`Simple project with plugin`, `provided module names cache ...`, etc.). No
  separate test regression.

  ---

  ### Fix

  Swap the doc-link for a plain code span — renders the same, resolves nothing:

  ```diff
  - * Maps each [[ProjectRef]] of the current build to its extracted project data.
  + * Maps each `ProjectRef` of the current build to its extracted project data.
  ```

  ### Verification

  Locally on this branch (off current `master`):

  - `core/doc`, `packaging/doc`, `ideaSupport/doc` → all generate successfully (3/3), zero errors
  - the `publishLocal` path the integration tests use no longer fails

  The other doc-links added in #147 (`[[projectMap]]`, `[[processLibraries]]`, `[[buildExternalProjectData]]`, `[[SbtPackageProjectData]]`) all point to in-project
  members and resolve fine — `[[ProjectRef]]` was the only break.